### PR TITLE
Stabilize Moodle data extraction and local export

### DIFF
--- a/moodle-ai-extension/background.js
+++ b/moodle-ai-extension/background.js
@@ -1,38 +1,313 @@
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message.type === "get_data") {
-        chrome.storage.local.get("moodle_data", (result) => {
-            sendResponse({ data: result.moodle_data || null });
+const STORAGE_KEY = "moodleData";
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+
+const activeTabs = new Map();
+
+const defaultData = () => ({
+    student: {
+        student_id: null,
+        program: null,
+        enrollment_year: null
+    },
+    courses: [],
+    behavior: {
+        total_time_spent_on_moodle: 0,
+        active_days_count: 0,
+        session_count: 0,
+        average_session_duration: 0,
+        clicks_per_session: 0,
+        peak_activity_hours: []
+    },
+    events: [],
+    grades: [],
+    learning_materials: [],
+    _meta: {
+        activeDays: [],
+        hourCounts: {},
+        lastActivity: null,
+        sessionStart: null,
+        sessionClicks: 0
+    }
+});
+
+const getStoredData = async () => {
+    const result = await chrome.storage.local.get(STORAGE_KEY);
+    return result[STORAGE_KEY] || defaultData();
+};
+
+const saveStoredData = async (data) => {
+    await chrome.storage.local.set({ [STORAGE_KEY]: data });
+};
+
+const toCourseMap = (courses) => {
+    const map = new Map();
+    courses.forEach((course) => {
+        if (course.course_id) {
+            map.set(course.course_id, { ...course });
+        }
+    });
+    return map;
+};
+
+const mergeCourse = (coursesMap, course) => {
+    if (!course?.course_id) return;
+    const existing = coursesMap.get(course.course_id);
+    if (!existing) {
+        coursesMap.set(course.course_id, {
+            course_id: course.course_id,
+            course_name: course.course_name || "Unknown Course",
+            total_visits: 0,
+            last_access_time: null,
+            total_time_spent_seconds: 0,
+            number_of_resources_clicked: 0,
+            number_of_assignments_viewed: 0,
+            number_of_quizzes_viewed: 0
         });
-        return true; // async
+    } else if (course.course_name && existing.course_name !== course.course_name) {
+        existing.course_name = course.course_name;
+        coursesMap.set(course.course_id, existing);
+    }
+};
+
+const updateSessionMetrics = (data, timestamp, isClick) => {
+    const meta = data._meta || defaultData()._meta;
+    const behavior = data.behavior;
+    const lastActivity = meta.lastActivity;
+
+    const startNewSession = () => {
+        meta.sessionStart = timestamp;
+        meta.sessionClicks = 0;
+        behavior.session_count += 1;
+    };
+
+    if (!meta.sessionStart) {
+        startNewSession();
+    } else if (lastActivity && timestamp - lastActivity > SESSION_TIMEOUT_MS) {
+        const duration = Math.max(0, lastActivity - meta.sessionStart);
+        if (duration > 0) {
+            behavior.average_session_duration =
+                (behavior.average_session_duration * (behavior.session_count - 1) + duration / 1000) /
+                behavior.session_count;
+            behavior.clicks_per_session =
+                (behavior.clicks_per_session * (behavior.session_count - 1) + meta.sessionClicks) /
+                behavior.session_count;
+        }
+        startNewSession();
+    }
+
+    if (isClick) {
+        meta.sessionClicks += 1;
+    }
+
+    meta.lastActivity = timestamp;
+    data._meta = meta;
+};
+
+const updateActiveDayAndHours = (data, timestamp) => {
+    const meta = data._meta || defaultData()._meta;
+    const dayKey = new Date(timestamp).toISOString().slice(0, 10);
+    if (!meta.activeDays.includes(dayKey)) {
+        meta.activeDays.push(dayKey);
+    }
+    data.behavior.active_days_count = meta.activeDays.length;
+
+    const hour = new Date(timestamp).getHours();
+    meta.hourCounts[hour] = (meta.hourCounts[hour] || 0) + 1;
+    const sortedHours = Object.entries(meta.hourCounts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([hourKey]) => Number(hourKey));
+    data.behavior.peak_activity_hours = sortedHours;
+    data._meta = meta;
+};
+
+const addEvent = (data, event) => {
+    const eventId = `${event.timestamp}-${event.page_type}-${event.action_type}-${event.course_id || "unknown"}`;
+    const exists = data.events.some((item) => item._id === eventId);
+    if (!exists) {
+        data.events.push({ ...event, _id: eventId });
+    }
+};
+
+const mergeGrades = (data, grades) => {
+    grades.forEach((grade) => {
+        const key = `${grade.course_id}-${grade.item_name}-${grade.item_type}-${grade.submission_time || ""}`;
+        if (!data.grades.some((existing) => existing._key === key)) {
+            data.grades.push({ ...grade, _key: key });
+        }
+    });
+};
+
+const mergeMaterials = (data, materials) => {
+    materials.forEach((material) => {
+        const key = `${material.course_id}-${material.url}`;
+        if (!data.learning_materials.some((existing) => existing._key === key)) {
+            data.learning_materials.push({ ...material, _key: key });
+        }
+    });
+};
+
+const finalizeActiveTab = async (tabId, endTime) => {
+    const active = activeTabs.get(tabId);
+    if (!active) return;
+    const durationMs = Math.max(0, endTime - active.startTime);
+    if (durationMs <= 0) {
+        activeTabs.delete(tabId);
+        return;
+    }
+    const data = await getStoredData();
+    const coursesMap = toCourseMap(data.courses);
+    mergeCourse(coursesMap, { course_id: active.courseId, course_name: active.courseName });
+
+    const course = coursesMap.get(active.courseId);
+    if (course) {
+        course.total_time_spent_seconds += Math.round(durationMs / 1000);
+        course.last_access_time = new Date(endTime).toISOString();
+        coursesMap.set(active.courseId, course);
+    }
+
+    data.behavior.total_time_spent_on_moodle += Math.round(durationMs / 1000);
+    updateSessionMetrics(data, endTime, false);
+    updateActiveDayAndHours(data, endTime);
+
+    data.courses = Array.from(coursesMap.values());
+    await saveStoredData(data);
+    activeTabs.delete(tabId);
+};
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    const tabId = sender.tab?.id;
+
+    if (message.type === "get_data") {
+        chrome.storage.local.get(STORAGE_KEY, (result) => {
+            sendResponse({ data: result[STORAGE_KEY] || null });
+        });
+        return true;
     }
 
     if (message.type === "clear_data") {
-        chrome.storage.local.remove("moodle_data", () => {
+        chrome.storage.local.remove(STORAGE_KEY, () => {
             sendResponse({ status: "cleared" });
         });
         return true;
     }
 
-    if (message.type === "send_to_backend") {
-        chrome.storage.local.get("moodle_data", async (result) => {
-            const data = result.moodle_data;
-            if (!data) return sendResponse({ status: "no_data" });
-
-            try {
-                await fetch("http://localhost:8000/ingest", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify(data)
+    if (message.type === "page_view") {
+        (async () => {
+            const payload = message.payload;
+            const timestamp = payload.timestamp || Date.now();
+            if (typeof tabId === "number") {
+                await finalizeActiveTab(tabId, timestamp);
+                activeTabs.set(tabId, {
+                    startTime: timestamp,
+                    courseId: payload.course_id,
+                    courseName: payload.course_name,
+                    pageType: payload.page_type
                 });
-
-                const predictRes = await fetch("http://localhost:8000/predict", { method: "POST" });
-                const storeRes = await fetch("http://localhost:8000/store_result", { method: "POST" });
-
-                sendResponse({ status: "success", predictRes, storeRes });
-            } catch (err) {
-                sendResponse({ status: "error", error: err.message });
             }
-        });
+
+            const data = await getStoredData();
+            const coursesMap = toCourseMap(data.courses);
+            mergeCourse(coursesMap, { course_id: payload.course_id, course_name: payload.course_name });
+            const course = coursesMap.get(payload.course_id);
+            if (course) {
+                course.total_visits += 1;
+                course.last_access_time = new Date(timestamp).toISOString();
+                if (payload.page_type === "assignment") {
+                    course.number_of_assignments_viewed += 1;
+                } else if (payload.page_type === "quiz") {
+                    course.number_of_quizzes_viewed += 1;
+                } else if (payload.page_type === "resource") {
+                    course.number_of_resources_clicked += 1;
+                }
+                coursesMap.set(payload.course_id, course);
+            }
+            data.courses = Array.from(coursesMap.values());
+
+            updateSessionMetrics(data, timestamp, false);
+            updateActiveDayAndHours(data, timestamp);
+            addEvent(data, {
+                timestamp,
+                course_id: payload.course_id,
+                page_type: payload.page_type,
+                action_type: "view"
+            });
+
+            await saveStoredData(data);
+            sendResponse({ status: "ok" });
+        })();
         return true;
     }
+
+    if (message.type === "page_hidden") {
+        (async () => {
+            const timestamp = message.payload?.timestamp || Date.now();
+            if (typeof tabId === "number") {
+                await finalizeActiveTab(tabId, timestamp);
+            }
+            sendResponse({ status: "ok" });
+        })();
+        return true;
+    }
+
+    if (message.type === "interaction") {
+        (async () => {
+            const payload = message.payload;
+            const timestamp = payload.timestamp || Date.now();
+            const data = await getStoredData();
+
+            updateSessionMetrics(data, timestamp, payload.action_type === "click");
+            updateActiveDayAndHours(data, timestamp);
+            addEvent(data, {
+                timestamp,
+                course_id: payload.course_id,
+                page_type: payload.page_type,
+                action_type: payload.action_type
+            });
+
+            await saveStoredData(data);
+            sendResponse({ status: "ok" });
+        })();
+        return true;
+    }
+
+    if (message.type === "identity") {
+        (async () => {
+            const data = await getStoredData();
+            data.student = {
+                student_id: message.payload.student_id || data.student.student_id,
+                program: message.payload.program || data.student.program,
+                enrollment_year: message.payload.enrollment_year || data.student.enrollment_year
+            };
+            await saveStoredData(data);
+            sendResponse({ status: "ok" });
+        })();
+        return true;
+    }
+
+    if (message.type === "grades") {
+        (async () => {
+            const data = await getStoredData();
+            mergeGrades(data, message.payload || []);
+            await saveStoredData(data);
+            sendResponse({ status: "ok" });
+        })();
+        return true;
+    }
+
+    if (message.type === "materials") {
+        (async () => {
+            const data = await getStoredData();
+            mergeMaterials(data, message.payload || []);
+            await saveStoredData(data);
+            sendResponse({ status: "ok" });
+        })();
+        return true;
+    }
+
+    return false;
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+    finalizeActiveTab(tabId, Date.now());
 });

--- a/moodle-ai-extension/content.js
+++ b/moodle-ai-extension/content.js
@@ -1,194 +1,252 @@
-// content.js - Moodle AI Scraper (Working Version)
+// content.js - Moodle data extraction and event tracking
 (() => {
-    console.log("[MoodleScraper] Content script started");
+    const STORAGE_ID_KEY = "moodle_student_id";
 
-    // --- Student ID ---
-    const studentId = localStorage.getItem("student_id") || generateHashedId();
-    localStorage.setItem("student_id", studentId);
-
-    // --- State ---
-    const state = {
-        clicks: 0,
-        lastActivity: Date.now(),
-        sessions: [],
-        currentSession: { start: Date.now(), end: null, active_time_ms: 0, idle_time_ms: 0 },
-        courses: {}
+    const isMoodlePage = () => {
+        if (!document?.body) return false;
+        const metaGenerator = document.querySelector('meta[name="generator"]')?.getAttribute("content") || "";
+        const bodyClass = document.body.className || "";
+        const url = window.location.href;
+        return (
+            metaGenerator.toLowerCase().includes("moodle") ||
+            bodyClass.includes("path-") ||
+            url.includes("/course/view.php") ||
+            url.includes("/mod/") ||
+            url.includes("/my/") ||
+            url.includes("/grade/report")
+        );
     };
 
-    let idleStart = Date.now();
-
-    // --- Activity Tracking ---
-    document.addEventListener("click", () => {
-        state.clicks += 1;
-        state.lastActivity = Date.now();
-    });
-
-    document.addEventListener("mousemove", () => {
-        const now = Date.now();
-        if (now - state.lastActivity > 60000) { // idle
-            state.currentSession.idle_time_ms += now - idleStart;
-            idleStart = now;
-        }
-        state.lastActivity = now;
-    });
-
-    function generateHashedId() {
-        return 'stu_' + Math.random().toString(36).substr(2, 9);
+    if (!isMoodlePage()) {
+        return;
     }
 
-    // --- Page detection ---
-    function detectPageType() {
-        const url = window.location.href;
-        if (url.includes("/my/")) return "DASHBOARD";
-        if (url.includes("/course/view.php")) return "COURSE";
-        if (url.includes("/mod/assign/")) return "ASSIGNMENTS";
-        if (url.includes("/grade/report/user")) return "GRADES";
-        return "UNKNOWN";
-    }
+    const generateHashedId = () => `stu_${Math.random().toString(36).slice(2, 10)}`;
 
-    function waitForElement(selector, callback) {
-        const el = document.querySelector(selector);
-        if (el) return callback();
+    const getStudentIdentity = () => {
+        const storedId = localStorage.getItem(STORAGE_ID_KEY) || generateHashedId();
+        localStorage.setItem(STORAGE_ID_KEY, storedId);
 
-        const observer = new MutationObserver(() => {
-            const el = document.querySelector(selector);
-            if (el) {
-                observer.disconnect();
-                callback();
-            }
-        });
-        observer.observe(document.body, { childList: true, subtree: true });
-    }
+        const profileText = document.querySelector(".page-header-headings")?.textContent || "";
+        const programMatch = document.body.textContent?.match(/Program(?:me)?\s*:\s*([A-Za-z0-9\s&-]+)/i);
+        const enrollmentMatch = document.body.textContent?.match(/Enrollment\s*Year\s*:\s*(\d{4})/i);
 
-    // --- Scrape functions ---
-    function scrapeDashboard() {
-        const courses = [...document.querySelectorAll('a[href*="course/view.php"]')]
-            .map(a => ({ title: a.innerText.trim(), url: a.href }))
-            .filter(c => c.title);
-
-        courses.forEach(c => {
-            if (!state.courses[c.url]) {
-                state.courses[c.url] = {
-                    name: c.title,
-                    visits: 1,
-                    time_spent_ms: 0,
-                    assignments: [],
-                    quizzes: [],
-                    resources: [],
-                    finalGrade: null
-                };
-            } else {
-                state.courses[c.url].visits += 1;
-            }
-        });
-
-        console.log("[MoodleScraper] Dashboard courses:", Object.keys(state.courses));
-    }
-
-    function scrapeCoursePage() {
-        const name = document.querySelector("h1")?.innerText.trim();
-        if (!name) return;
-        console.log("[MoodleScraper] On course page:", name);
-    }
-
-    function scrapeAssignmentsPage() {
-        const assignments = [];
-
-        document.querySelectorAll('a[href*="/mod/assign/view.php"]').forEach(link => {
-            const container = link.closest(".activity.assign");
-            const text = container?.innerText || "";
-            const due = text.match(/Due[:\s].*/i)?.[0] || null;
-
-            assignments.push({
-                title: link.innerText.trim(),
-                url: link.href,
-                dueDate: due,
-                status: null,
-                grade: null
-            });
-
-            // Map to course
-            const courseUrl = window.location.href.split("?")[0]; // crude course identifier
-            if (!state.courses[courseUrl]) {
-                state.courses[courseUrl] = { name: "Unknown Course", visits: 1, time_spent_ms: 0, assignments: [], quizzes: [], resources: [], finalGrade: null };
-            }
-            state.courses[courseUrl].assignments.push(assignments[assignments.length - 1]);
-        });
-
-        console.log("[MoodleScraper] Assignments scraped:", assignments);
-    }
-
-    function scrapeGradesPage() {
-        const grades = [];
-
-        document.querySelectorAll("table.user-grade tbody tr").forEach(row => {
-            const item = row.querySelector("th.column-itemname")?.innerText.trim();
-            const grade = row.querySelector("td.column-grade")?.innerText.trim();
-            const max = row.querySelector("td.column-range")?.innerText.trim();
-
-            if (item && grade) {
-                grades.push({ item, grade, max });
-
-                // Map to course
-                const courseUrl = window.location.href.split("?")[0];
-                if (!state.courses[courseUrl]) {
-                    state.courses[courseUrl] = { name: "Unknown Course", visits: 1, time_spent_ms: 0, assignments: [], quizzes: [], resources: [], finalGrade: null };
-                }
-                state.courses[courseUrl].grades = state.courses[courseUrl].grades || [];
-                state.courses[courseUrl].grades.push({ item, grade, max });
-            }
-        });
-
-        console.log("[MoodleScraper] Grades scraped:", grades);
-    }
-
-    // --- Main runner ---
-    function runScraper() {
-        const page = detectPageType();
-        console.log("[MoodleScraper] Detected page:", page);
-
-        switch (page) {
-            case "DASHBOARD":
-                waitForElement('a[href*="course/view.php"]', scrapeDashboard);
-                break;
-            case "COURSE":
-                waitForElement("h1", scrapeCoursePage);
-                break;
-            case "ASSIGNMENTS":
-                waitForElement('a[href*="/mod/assign/view.php"]', scrapeAssignmentsPage);
-                break;
-            case "GRADES":
-                waitForElement("table.user-grade", scrapeGradesPage);
-                break;
-        }
-
-        // Update session
-        state.currentSession.end = Date.now();
-        state.currentSession.active_time_ms = state.currentSession.end - state.currentSession.start - state.currentSession.idle_time_ms;
-        if (state.currentSession.active_time_ms > 0 || state.currentSession.idle_time_ms > 0) {
-            state.sessions.push({ ...state.currentSession });
-            state.currentSession = { start: Date.now(), end: null, active_time_ms: 0, idle_time_ms: 0 };
-        }
-
-        // Persist data to chrome.storage
-        const data = {
-            student_id: studentId,
-            clicks: state.clicks,
-            lastActivity: state.lastActivity,
-            sessions: state.sessions,
-            courses: state.courses
+        return {
+            student_id: storedId,
+            program: programMatch?.[1]?.trim() || (profileText.includes("Program") ? profileText.trim() : null),
+            enrollment_year: enrollmentMatch?.[1] || null
         };
+    };
 
-        chrome.storage.local.set({ moodle_data: data }, () => {
-            console.log("[MoodleScraper] Data saved:", data);
+    const detectPageType = () => {
+        const url = window.location.href;
+        if (url.includes("/my/") || url.includes("/my/index.php")) return "dashboard";
+        if (url.includes("/course/view.php")) return "course";
+        if (url.includes("/mod/assign/")) return "assignment";
+        if (url.includes("/mod/quiz/")) return "quiz";
+        if (url.includes("/grade/report/user")) return "grades";
+        if (url.includes("/mod/resource/") || url.includes("/mod/page/") || url.includes("/mod/url/")) return "resource";
+        return "resource";
+    };
+
+    const parseCourseId = (url) => {
+        const match = url.match(/[?&]id=(\d+)/);
+        if (match) return match[1];
+        const bodyMatch = document.body.className.match(/course-(\d+)/);
+        return bodyMatch?.[1] || null;
+    };
+
+    const getCourseContext = () => {
+        const url = window.location.href;
+        const courseId = parseCourseId(url) || document.querySelector('a[href*="course/view.php?id="]')?.href?.match(/[?&]id=(\d+)/)?.[1];
+        const courseName =
+            document.querySelector("h1")?.textContent?.trim() ||
+            document.querySelector(".page-header-headings h1")?.textContent?.trim() ||
+            document.querySelector('a[href*="course/view.php"]')?.textContent?.trim();
+        return {
+            course_id: courseId,
+            course_name: courseName || "Unknown Course"
+        };
+    };
+
+    const cleanText = (value) => value?.replace(/\s+/g, " ").trim() || null;
+
+    const extractMaterialsFromCourse = (courseId) => {
+        const materials = [];
+        document.querySelectorAll(".activity").forEach((activity) => {
+            const link = activity.querySelector("a");
+            const title = cleanText(activity.querySelector(".instancename")?.textContent || link?.textContent);
+            const url = link?.href;
+            if (!title || !url) return;
+
+            const classList = activity.className;
+            let materialType = "resource";
+            if (classList.includes("assign")) materialType = "assignment";
+            if (classList.includes("quiz")) materialType = "quiz";
+            if (classList.includes("resource")) materialType = "pdf";
+            if (classList.includes("page")) materialType = "lecture";
+            if (classList.includes("url")) materialType = "link";
+
+            const availability = cleanText(activity.querySelector(".availabilityinfo")?.textContent);
+            const dueDate = cleanText(activity.querySelector(".activitydate")?.textContent);
+
+            materials.push({
+                course_id: courseId,
+                material_type: materialType,
+                title,
+                url,
+                availability_status: availability,
+                due_date: dueDate
+            });
         });
-    }
+        return materials;
+    };
 
-    // --- Mutation observer for dynamic content ---
-    const observer = new MutationObserver(() => runScraper());
+    const extractGradesFromTable = (courseId) => {
+        const grades = [];
+        document.querySelectorAll("table.user-grade tbody tr").forEach((row) => {
+            const itemName = cleanText(row.querySelector("th.column-itemname")?.textContent);
+            const gradeText = cleanText(row.querySelector("td.column-grade")?.textContent);
+            const rangeText = cleanText(row.querySelector("td.column-range")?.textContent);
+            if (!itemName || !gradeText) return;
+
+            const [gradeValue] = gradeText.split("/");
+            const maxGrade = rangeText?.split("/")[1] || rangeText;
+            const gradeNumber = parseFloat(gradeValue);
+            const maxNumber = parseFloat(maxGrade);
+            const percentage =
+                Number.isFinite(gradeNumber) && Number.isFinite(maxNumber) && maxNumber > 0
+                    ? Math.round((gradeNumber / maxNumber) * 100)
+                    : null;
+
+            grades.push({
+                course_id: courseId,
+                item_name: itemName,
+                item_type: itemName.toLowerCase().includes("quiz") ? "quiz" : "assignment",
+                grade: gradeText,
+                max_grade: rangeText,
+                percentage,
+                submission_status: cleanText(row.querySelector("td.column-status")?.textContent),
+                submission_time: cleanText(row.querySelector("td.column-lastaccess")?.textContent)
+            });
+        });
+        return grades;
+    };
+
+    const extractAssignmentDetails = (courseId) => {
+        const title = cleanText(document.querySelector("h1")?.textContent);
+        const status = cleanText(document.querySelector(".submissionstatustable")?.textContent);
+        const dueDate = cleanText(document.querySelector(".submissionstatustable .duedate")?.textContent);
+        const grade = cleanText(document.querySelector(".gradingtable .grade")?.textContent);
+        return title
+            ? [
+                  {
+                      course_id: courseId,
+                      item_name: title,
+                      item_type: "assignment",
+                      grade,
+                      max_grade: null,
+                      percentage: null,
+                      submission_status: status,
+                      submission_time: null
+                  }
+              ]
+            : [];
+    };
+
+    const extractQuizDetails = (courseId) => {
+        const title = cleanText(document.querySelector("h1")?.textContent);
+        const gradeSummary = cleanText(document.querySelector(".quizgradefeedback")?.textContent);
+        const gradeInfo = cleanText(document.querySelector(".quizinfo")?.textContent);
+        return title
+            ? [
+                  {
+                      course_id: courseId,
+                      item_name: title,
+                      item_type: "quiz",
+                      grade: gradeSummary,
+                      max_grade: gradeInfo,
+                      percentage: null,
+                      submission_status: null,
+                      submission_time: null
+                  }
+              ]
+            : [];
+    };
+
+    const sendMessage = (type, payload) => {
+        chrome.runtime.sendMessage({ type, payload }, () => {});
+    };
+
+    const sendPageView = (pageType, course) => {
+        sendMessage("page_view", {
+            page_type: pageType,
+            course_id: course.course_id,
+            course_name: course.course_name,
+            url: window.location.href,
+            timestamp: Date.now()
+        });
+    };
+
+    const handleScrape = () => {
+        const pageType = detectPageType();
+        const course = getCourseContext();
+
+        sendMessage("identity", getStudentIdentity());
+        sendPageView(pageType, course);
+
+        if (pageType === "course") {
+            const materials = extractMaterialsFromCourse(course.course_id);
+            if (materials.length) {
+                sendMessage("materials", materials);
+            }
+        }
+
+        if (pageType === "grades") {
+            const grades = extractGradesFromTable(course.course_id);
+            if (grades.length) {
+                sendMessage("grades", grades);
+            }
+        }
+
+        if (pageType === "assignment") {
+            const grades = extractAssignmentDetails(course.course_id);
+            if (grades.length) {
+                sendMessage("grades", grades);
+            }
+        }
+
+        if (pageType === "quiz") {
+            const grades = extractQuizDetails(course.course_id);
+            if (grades.length) {
+                sendMessage("grades", grades);
+            }
+        }
+    };
+
+    document.addEventListener("click", () => {
+        const pageType = detectPageType();
+        const course = getCourseContext();
+        sendMessage("interaction", {
+            page_type: pageType,
+            course_id: course.course_id,
+            action_type: "click",
+            timestamp: Date.now()
+        });
+    });
+
+    document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "hidden") {
+            sendMessage("page_hidden", { timestamp: Date.now() });
+        }
+    });
+
+    window.addEventListener("beforeunload", () => {
+        sendMessage("page_hidden", { timestamp: Date.now() });
+    });
+
+    const observer = new MutationObserver(() => handleScrape());
     observer.observe(document.body, { childList: true, subtree: true });
 
-    // --- Initial run ---
-    window.addEventListener("load", runScraper);
-
+    window.addEventListener("load", handleScrape);
 })();

--- a/moodle-ai-extension/manifest.json
+++ b/moodle-ai-extension/manifest.json
@@ -5,25 +5,22 @@
   "description": "Client-side assistant for MIU Moodle data extraction and AI risk prediction",
   "permissions": [
     "storage",
-    "activeTab",
-    "scripting",
     "tabs"
   ],
   "host_permissions": [
-    "https://*.miu.edu.eg/*",
-    "http://localhost:8000/*"
+    "<all_urls>"
   ],
   "action": {
     "default_popup": "popup.html",
     "default_title": "Moodle AI Assistant"
   },
-"content_scripts": [
-  {
-    "matches": ["https://*.miu.edu.eg/*"],
-    "js": ["content.js"],
-    "run_at": "document_idle"
-  }
-],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
   "background": {
     "service_worker": "background.js"
   }

--- a/moodle-ai-extension/popup.html
+++ b/moodle-ai-extension/popup.html
@@ -11,10 +11,10 @@
 </style>
 </head>
 <body>
-  <h2>Moodle AI Data</h2>
+  <h2>Moodle Data Collected</h2>
   <button id="loadDataBtn">Load Stored Data</button>
   <button id="downloadJsonBtn">Download JSON</button>
-  <button id="sendBackendBtn">Send to Backend</button>
+  <button id="clearDataBtn">Clear Data</button>
 
   <div id="output">Data will appear here...</div>
 

--- a/moodle-ai-extension/popup.js
+++ b/moodle-ai-extension/popup.js
@@ -1,31 +1,41 @@
 const loadDataBtn = document.getElementById("loadDataBtn");
 const downloadJsonBtn = document.getElementById("downloadJsonBtn");
-const sendBackendBtn = document.getElementById("sendBackendBtn");
+const clearDataBtn = document.getElementById("clearDataBtn");
 const outputDiv = document.getElementById("output");
 
-const STORAGE_KEY = "MIU_MOODLE_DATA_V1";
+const STORAGE_KEY = "moodleData";
 
-function logOutput(msg) {
-    outputDiv.textContent += msg + "\n";
-}
+const sanitizePayload = (data) => {
+    if (!data) return null;
+    const { _meta, events, grades, learning_materials, courses, behavior, student } = data;
+    return {
+        student,
+        courses,
+        behavior,
+        events: (events || []).map(({ _id, ...event }) => event),
+        grades: (grades || []).map(({ _key, ...grade }) => grade),
+        learning_materials: (learning_materials || []).map(({ _key, ...material }) => material)
+    };
+};
 
 // --- Load stored data ---
 loadDataBtn.addEventListener("click", () => {
-    chrome.storage.local.get("moodleData", res => {
-        if (!res.moodleData?.payload) {
+    chrome.storage.local.get(STORAGE_KEY, res => {
+        if (!res[STORAGE_KEY]) {
             outputDiv.textContent = "No data found!";
             return;
         }
-        const data = res.moodleData.payload;
+        const data = sanitizePayload(res[STORAGE_KEY]);
         outputDiv.textContent = JSON.stringify(data, null, 2);
     });
 });
 
 // --- Download JSON ---
 downloadJsonBtn.addEventListener("click", () => {
-    chrome.storage.local.get("moodleData", res => {
-        if (!res.moodleData?.payload) return alert("No data to download.");
-        const blob = new Blob([JSON.stringify(res.moodleData.payload, null, 2)], { type: "application/json" });
+    chrome.storage.local.get(STORAGE_KEY, res => {
+        if (!res[STORAGE_KEY]) return alert("No data to download.");
+        const payload = sanitizePayload(res[STORAGE_KEY]);
+        const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
         const url = URL.createObjectURL(blob);
         const a = document.createElement("a");
         a.href = url;
@@ -35,38 +45,9 @@ downloadJsonBtn.addEventListener("click", () => {
     });
 });
 
-// --- Send to backend: ingest -> predict ---
-sendBackendBtn.addEventListener("click", async () => {
-    chrome.storage.local.get("moodleData", async res => {
-        if (!res.moodleData?.payload) return alert("No data to send.");
-        const rawPayload = res.moodleData.payload;
-
-        outputDiv.textContent = "Sending data to backend (/ingest)...\n";
-
-        try {
-            // 1️⃣ Send raw Moodle JSON to /ingest
-            const ingestResp = await fetch("http://localhost:8000/ingest", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(rawPayload)
-            });
-            const ingestData = await ingestResp.json();
-            logOutput("Ingest complete. Computed features:\n" + JSON.stringify(ingestData.features, null, 2));
-
-            // 2️⃣ Send features to /predict
-            const predictResp = await fetch("http://localhost:8000/predict", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(ingestData.features)
-            });
-            const predictData = await predictResp.json();
-            logOutput("\nPrediction complete:\n" + JSON.stringify(predictData, null, 2));
-
-            // Optionally: call /store_result if you have one
-            // await fetch("http://localhost:8000/store_result", { ... });
-
-        } catch (err) {
-            logOutput("Error sending to backend: " + err);
-        }
+// --- Clear data ---
+clearDataBtn.addEventListener("click", () => {
+    chrome.runtime.sendMessage({ type: "clear_data" }, () => {
+        outputDiv.textContent = "Data cleared.";
     });
 });


### PR DESCRIPTION
### Motivation
- Provide a robust, unified client-side data extraction layer for Moodle that collects student identity, course engagement, behavior sessions, interaction events, grades and learning materials into a single normalized JSON schema for later ML use.
- Replace ad-hoc per-page state with centralized background aggregation so time/session tracking and de-duplication are reliable across tabs and page navigations.
- Remove backend coupling from the popup and keep all functionality local (store/export/clear) to meet the requirement of no backend integration.

### Description
- Reworked the background service worker (`moodle-ai-extension/background.js`) to implement a unified `moodleData` schema, persistent `chrome.storage.local` helpers, session timeout handling, active tab tracking, session/behavior aggregation, event de-duplication, grade/material merging, and message handlers for `page_view`, `interaction`, `page_hidden`, `identity`, `grades`, `materials`, and `clear_data`.
- Rewrote the content script (`moodle-ai-extension/content.js`) to reliably detect Moodle pages, extract student identity, course context, learning materials, grades, assignment/quiz details and to send structured messages to the background worker for aggregation and event logging.
- Simplified the popup UI and logic (`moodle-ai-extension/popup.html` and `moodle-ai-extension/popup.js`) to load, sanitize, export, and clear the locally stored `moodleData` payload (removed backend send flow), and added a `sanitizePayload` step that strips internal keys before export.
- Updated `manifest.json` to use a single `STORAGE_KEY` and broaden `host_permissions`/`content_scripts.matches` to ensure scraping works across Moodle deployments and allowed the extension to run on relevant pages during development.

### Testing
- No automated tests were executed for this change set; only static edits and commits were performed in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983f5e234c4833296a10ca39eb4fe73)