### PR TITLE
Refocus Moodle extension on per-course extracted performance metrics

### DIFF
--- a/moodle-ai-extension/background.js
+++ b/moodle-ai-extension/background.js
@@ -1,7 +1,19 @@
 const STORAGE_KEY = "moodleData";
-const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
 
 const activeTabs = new Map();
+
+const createDefaultCourseMetrics = (courseId, courseName = "Unknown Course") => ({
+    course_id: courseId,
+    course_name: courseName,
+    // Extracted counters used by the popup (raw values only).
+    total_time_spent: 0,
+    total_visits: 0,
+    material_clicks: 0,
+    active_days: [],
+    quiz_attempts: 0,
+    assignment_submissions: 0,
+    last_access_time: null
+});
 
 const defaultData = () => ({
     student: {
@@ -9,117 +21,65 @@ const defaultData = () => ({
         program: null,
         enrollment_year: null
     },
-    courses: [],
-    behavior: {
-        total_time_spent_on_moodle: 0,
-        active_days_count: 0,
-        session_count: 0,
-        average_session_duration: 0,
-        clicks_per_session: 0,
-        peak_activity_hours: []
-    },
-    events: [],
-    grades: [],
-    learning_materials: [],
-    knowledge_base: {},
-    _meta: {
-        activeDays: [],
-        hourCounts: {},
-        lastActivity: null,
-        sessionStart: null,
-        sessionClicks: 0
-    }
+    // Metrics are isolated by course id to prevent cross-course pollution.
+    metricsByCourse: {},
+    events: []
 });
+
+const normalizeData = (data) => {
+    const normalized = data && typeof data === "object" ? data : defaultData();
+    normalized.student = normalized.student || defaultData().student;
+    normalized.metricsByCourse = normalized.metricsByCourse || {};
+    normalized.events = Array.isArray(normalized.events) ? normalized.events : [];
+
+    // Lightweight migration from older `courses` format.
+    if (Array.isArray(normalized.courses)) {
+        normalized.courses.forEach((course) => {
+            if (!course?.course_id) return;
+            const existing = normalized.metricsByCourse[course.course_id] || createDefaultCourseMetrics(course.course_id, course.course_name);
+            normalized.metricsByCourse[course.course_id] = {
+                ...existing,
+                course_name: course.course_name || existing.course_name,
+                total_time_spent: Number(existing.total_time_spent || course.total_time_spent_seconds || 0),
+                total_visits: Number(existing.total_visits || course.total_visits || 0),
+                material_clicks: Number(existing.material_clicks || course.number_of_resources_clicked || 0),
+                active_days: Array.isArray(existing.active_days) ? existing.active_days : [],
+                quiz_attempts: Number(existing.quiz_attempts || course.number_of_quizzes_viewed || 0),
+                assignment_submissions: Number(existing.assignment_submissions || course.number_of_assignments_viewed || 0),
+                last_access_time: existing.last_access_time || course.last_access_time || null
+            };
+        });
+        delete normalized.courses;
+    }
+
+    return normalized;
+};
 
 const getStoredData = async () => {
     const result = await chrome.storage.local.get(STORAGE_KEY);
-    return result[STORAGE_KEY] || defaultData();
+    return normalizeData(result[STORAGE_KEY]);
 };
 
 const saveStoredData = async (data) => {
-    await chrome.storage.local.set({ [STORAGE_KEY]: data });
+    await chrome.storage.local.set({ [STORAGE_KEY]: normalizeData(data) });
 };
 
-const toCourseMap = (courses) => {
-    const map = new Map();
-    courses.forEach((course) => {
-        if (course.course_id) {
-            map.set(course.course_id, { ...course });
-        }
-    });
-    return map;
-};
-
-const mergeCourse = (coursesMap, course) => {
-    if (!course?.course_id) return;
-    const existing = coursesMap.get(course.course_id);
-    if (!existing) {
-        coursesMap.set(course.course_id, {
-            course_id: course.course_id,
-            course_name: course.course_name || "Unknown Course",
-            total_visits: 0,
-            last_access_time: null,
-            total_time_spent_seconds: 0,
-            number_of_resources_clicked: 0,
-            number_of_assignments_viewed: 0,
-            number_of_quizzes_viewed: 0
-        });
-    } else if (course.course_name && existing.course_name !== course.course_name) {
-        existing.course_name = course.course_name;
-        coursesMap.set(course.course_id, existing);
+const ensureCourseMetrics = (data, courseId, courseName) => {
+    if (!courseId) return null;
+    if (!data.metricsByCourse[courseId]) {
+        data.metricsByCourse[courseId] = createDefaultCourseMetrics(courseId, courseName);
     }
+    if (courseName && data.metricsByCourse[courseId].course_name !== courseName) {
+        data.metricsByCourse[courseId].course_name = courseName;
+    }
+    return data.metricsByCourse[courseId];
 };
 
-const updateSessionMetrics = (data, timestamp, isClick) => {
-    const meta = data._meta || defaultData()._meta;
-    const behavior = data.behavior;
-    const lastActivity = meta.lastActivity;
-
-    const startNewSession = () => {
-        meta.sessionStart = timestamp;
-        meta.sessionClicks = 0;
-        behavior.session_count += 1;
-    };
-
-    if (!meta.sessionStart) {
-        startNewSession();
-    } else if (lastActivity && timestamp - lastActivity > SESSION_TIMEOUT_MS) {
-        const duration = Math.max(0, lastActivity - meta.sessionStart);
-        if (duration > 0) {
-            behavior.average_session_duration =
-                (behavior.average_session_duration * (behavior.session_count - 1) + duration / 1000) /
-                behavior.session_count;
-            behavior.clicks_per_session =
-                (behavior.clicks_per_session * (behavior.session_count - 1) + meta.sessionClicks) /
-                behavior.session_count;
-        }
-        startNewSession();
-    }
-
-    if (isClick) {
-        meta.sessionClicks += 1;
-    }
-
-    meta.lastActivity = timestamp;
-    data._meta = meta;
-};
-
-const updateActiveDayAndHours = (data, timestamp) => {
-    const meta = data._meta || defaultData()._meta;
+const markActiveDay = (courseMetrics, timestamp) => {
     const dayKey = new Date(timestamp).toISOString().slice(0, 10);
-    if (!meta.activeDays.includes(dayKey)) {
-        meta.activeDays.push(dayKey);
+    if (!courseMetrics.active_days.includes(dayKey)) {
+        courseMetrics.active_days.push(dayKey);
     }
-    data.behavior.active_days_count = meta.activeDays.length;
-
-    const hour = new Date(timestamp).getHours();
-    meta.hourCounts[hour] = (meta.hourCounts[hour] || 0) + 1;
-    const sortedHours = Object.entries(meta.hourCounts)
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 3)
-        .map(([hourKey]) => Number(hourKey));
-    data.behavior.peak_activity_hours = sortedHours;
-    data._meta = meta;
 };
 
 const addEvent = (data, event) => {
@@ -130,73 +90,48 @@ const addEvent = (data, event) => {
     }
 };
 
-const mergeGrades = (data, grades) => {
+const extractAttemptsFromGrades = (grades = []) => {
+    let quizAttempts = 0;
+    let assignmentSubmissions = 0;
+
     grades.forEach((grade) => {
-        const key = `${grade.course_id}-${grade.item_name}-${grade.item_type}-${grade.submission_time || ""}`;
-        if (!data.grades.some((existing) => existing._key === key)) {
-            data.grades.push({ ...grade, _key: key });
-        }
-    });
-};
+        const type = String(grade.item_type || "").toLowerCase();
+        const status = String(grade.submission_status || "").toLowerCase();
+        const hasGrade = String(grade.grade || "").trim().length > 0;
 
-
-const buildKnowledgeBase = (materials = []) => {
-    const knowledgeBase = {};
-
-    materials.forEach((material) => {
-        const courseName = material.course_name || `Course ${material.course_id || "Unknown"}`;
-        if (!knowledgeBase[courseName]) {
-            knowledgeBase[courseName] = {};
+        if (type.includes("quiz")) {
+            quizAttempts += 1;
         }
 
-        const tags = Array.isArray(material.semantic_tags) && material.semantic_tags.length ? material.semantic_tags : ["general"];
-        tags.forEach((tag) => {
-            if (!knowledgeBase[courseName][tag]) {
-                knowledgeBase[courseName][tag] = [];
-            }
-            knowledgeBase[courseName][tag].push(material);
-        });
-    });
-
-    return knowledgeBase;
-};
-const mergeMaterials = (data, materials) => {
-    materials.forEach((material) => {
-        const stableMaterialId = material.material_id || material.url || material.title || "unknown";
-        const key = `${material.course_id || "unknown"}-${stableMaterialId}-${material.url || "no-url"}`;
-        if (!data.learning_materials.some((existing) => existing._key === key)) {
-            data.learning_materials.push({ ...material, _key: key });
+        if (type.includes("assignment") && (hasGrade || status.includes("submitted") || status.includes("graded"))) {
+            assignmentSubmissions += 1;
         }
     });
 
-    data.knowledge_base = buildKnowledgeBase(data.learning_materials);
+    return { quizAttempts, assignmentSubmissions };
 };
 
 const finalizeActiveTab = async (tabId, endTime) => {
     const active = activeTabs.get(tabId);
     if (!active) return;
-    const durationMs = Math.max(0, endTime - active.startTime);
-    if (durationMs <= 0) {
+
+    const data = await getStoredData();
+    const courseMetrics = ensureCourseMetrics(data, active.courseId, active.courseName);
+    if (!courseMetrics) {
         activeTabs.delete(tabId);
         return;
     }
-    const data = await getStoredData();
-    const coursesMap = toCourseMap(data.courses);
-    mergeCourse(coursesMap, { course_id: active.courseId, course_name: active.courseName });
 
-    const course = coursesMap.get(active.courseId);
-    if (course) {
-        course.total_time_spent_seconds += Math.round(durationMs / 1000);
-        course.last_access_time = new Date(endTime).toISOString();
-        coursesMap.set(active.courseId, course);
+    const durationMs = Math.max(0, endTime - active.startTime);
+    const elapsedSeconds = Math.round(durationMs / 1000);
+
+    if (elapsedSeconds > 0) {
+        courseMetrics.total_time_spent += elapsedSeconds;
+        courseMetrics.last_access_time = new Date(endTime).toISOString();
+        markActiveDay(courseMetrics, endTime);
+        await saveStoredData(data);
     }
 
-    data.behavior.total_time_spent_on_moodle += Math.round(durationMs / 1000);
-    updateSessionMetrics(data, endTime, false);
-    updateActiveDayAndHours(data, endTime);
-
-    data.courses = Array.from(coursesMap.values());
-    await saveStoredData(data);
     activeTabs.delete(tabId);
 };
 
@@ -205,8 +140,23 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     if (message.type === "get_data") {
         chrome.storage.local.get(STORAGE_KEY, (result) => {
-            sendResponse({ data: result[STORAGE_KEY] || null });
+            sendResponse({ data: normalizeData(result[STORAGE_KEY]) });
         });
+        return true;
+    }
+
+    if (message.type === "clear_course") {
+        (async () => {
+            const courseId = message.payload?.course_id;
+            if (!courseId) {
+                sendResponse({ status: "ignored" });
+                return;
+            }
+            const data = await getStoredData();
+            delete data.metricsByCourse[courseId];
+            await saveStoredData(data);
+            sendResponse({ status: "cleared", course_id: courseId });
+        })();
         return true;
     }
 
@@ -219,8 +169,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     if (message.type === "page_view") {
         (async () => {
-            const payload = message.payload;
+            const payload = message.payload || {};
             const timestamp = payload.timestamp || Date.now();
+
             if (typeof tabId === "number") {
                 await finalizeActiveTab(tabId, timestamp);
                 activeTabs.set(tabId, {
@@ -232,25 +183,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             }
 
             const data = await getStoredData();
-            const coursesMap = toCourseMap(data.courses);
-            mergeCourse(coursesMap, { course_id: payload.course_id, course_name: payload.course_name });
-            const course = coursesMap.get(payload.course_id);
-            if (course) {
-                course.total_visits += 1;
-                course.last_access_time = new Date(timestamp).toISOString();
-                if (payload.page_type === "assignment") {
-                    course.number_of_assignments_viewed += 1;
-                } else if (payload.page_type === "quiz") {
-                    course.number_of_quizzes_viewed += 1;
-                } else if (payload.page_type === "resource") {
-                    course.number_of_resources_clicked += 1;
-                }
-                coursesMap.set(payload.course_id, course);
-            }
-            data.courses = Array.from(coursesMap.values());
+            const courseMetrics = ensureCourseMetrics(data, payload.course_id, payload.course_name);
 
-            updateSessionMetrics(data, timestamp, false);
-            updateActiveDayAndHours(data, timestamp);
+            if (courseMetrics) {
+                courseMetrics.total_visits += 1;
+                courseMetrics.last_access_time = new Date(timestamp).toISOString();
+                markActiveDay(courseMetrics, timestamp);
+            }
+
             addEvent(data, {
                 timestamp,
                 course_id: payload.course_id,
@@ -277,17 +217,23 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     if (message.type === "interaction") {
         (async () => {
-            const payload = message.payload;
+            const payload = message.payload || {};
             const timestamp = payload.timestamp || Date.now();
             const data = await getStoredData();
+            const courseMetrics = ensureCourseMetrics(data, payload.course_id, payload.course_name);
 
-            updateSessionMetrics(data, timestamp, payload.action_type === "click");
-            updateActiveDayAndHours(data, timestamp);
+            if (courseMetrics) {
+                if (payload.action_type === "material_click") {
+                    courseMetrics.material_clicks += 1;
+                }
+                markActiveDay(courseMetrics, timestamp);
+            }
+
             addEvent(data, {
                 timestamp,
                 course_id: payload.course_id,
                 page_type: payload.page_type,
-                action_type: payload.action_type
+                action_type: payload.action_type || "interaction"
             });
 
             await saveStoredData(data);
@@ -312,18 +258,52 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     if (message.type === "grades") {
         (async () => {
+            const payload = Array.isArray(message.payload) ? message.payload : [];
             const data = await getStoredData();
-            mergeGrades(data, message.payload || []);
+            const byCourse = {};
+
+            payload.forEach((grade) => {
+                if (!grade?.course_id) return;
+                byCourse[grade.course_id] = byCourse[grade.course_id] || [];
+                byCourse[grade.course_id].push(grade);
+            });
+
+            Object.entries(byCourse).forEach(([courseId, items]) => {
+                const courseMetrics = ensureCourseMetrics(data, courseId, items[0]?.course_name);
+                if (!courseMetrics) return;
+                const { quizAttempts, assignmentSubmissions } = extractAttemptsFromGrades(items);
+                if (quizAttempts > 0) {
+                    courseMetrics.quiz_attempts = Math.max(courseMetrics.quiz_attempts, quizAttempts);
+                }
+                if (assignmentSubmissions > 0) {
+                    courseMetrics.assignment_submissions = Math.max(courseMetrics.assignment_submissions, assignmentSubmissions);
+                }
+            });
+
             await saveStoredData(data);
             sendResponse({ status: "ok" });
         })();
         return true;
     }
 
-    if (message.type === "materials") {
+    if (message.type === "metrics_update") {
         (async () => {
+            const payload = message.payload || {};
             const data = await getStoredData();
-            mergeMaterials(data, message.payload || []);
+            const courseMetrics = ensureCourseMetrics(data, payload.course_id, payload.course_name);
+
+            if (courseMetrics) {
+                if (Number.isFinite(payload.quiz_attempts)) {
+                    courseMetrics.quiz_attempts = Math.max(courseMetrics.quiz_attempts, payload.quiz_attempts);
+                }
+                if (Number.isFinite(payload.assignment_submissions)) {
+                    courseMetrics.assignment_submissions = Math.max(courseMetrics.assignment_submissions, payload.assignment_submissions);
+                }
+                if (payload.timestamp) {
+                    markActiveDay(courseMetrics, payload.timestamp);
+                }
+            }
+
             await saveStoredData(data);
             sendResponse({ status: "ok" });
         })();

--- a/moodle-ai-extension/content.js
+++ b/moodle-ai-extension/content.js
@@ -1,4 +1,4 @@
-// content.js - Moodle data extraction and event tracking
+// content.js - Moodle raw data extraction and interaction tracking
 (() => {
     const STORAGE_ID_KEY = "moodle_student_id";
 
@@ -71,236 +71,18 @@
 
     const cleanText = (value) => value?.replace(/\s+/g, " ").trim() || null;
 
-    const parseMaterialId = (url, activity) => {
-        const fromUrl = url?.match(/[?&](?:id|cmid)=([^&#]+)/i)?.[1];
-        if (fromUrl) return fromUrl;
-        return activity?.getAttribute("data-id") || activity?.id || `material_${Math.random().toString(36).slice(2, 9)}`;
-    };
-
-    const MIME_TYPE_MAP = [
-        { pattern: /application\/pdf/i, fileType: "pdf" },
-        { pattern: /presentation|powerpoint|vnd\.ms-powerpoint/i, fileType: "pptx" },
-        { pattern: /wordprocessingml|msword/i, fileType: "docx" },
-        { pattern: /spreadsheetml|vnd\.ms-excel/i, fileType: "xlsx" },
-        { pattern: /zip|compressed/i, fileType: "zip" },
-        { pattern: /text\/plain/i, fileType: "txt" },
-        { pattern: /text\/html/i, fileType: "html" }
-    ];
-
-    const mapMimeTypeToFileType = (contentType) => {
-        if (!contentType) return null;
-        const match = MIME_TYPE_MAP.find((item) => item.pattern.test(contentType));
-        return match?.fileType || null;
-    };
-
-    const parseFileTypeFromDom = (activity, title, url) => {
-        const icon = activity?.querySelector("img.activityicon");
-        const iconSrc = icon?.getAttribute("src") || "";
-        const iconAlt = icon?.getAttribute("alt") || "";
-        const dataType = activity?.getAttribute("data-filetype") || "";
-        const fileTypeClass = Array.from(activity?.classList || []).find((c) => c.startsWith("filetype-")) || "";
-        const fileTypeFromClass = fileTypeClass.replace("filetype-", "");
-        const hint = `${iconSrc} ${iconAlt} ${dataType} ${fileTypeFromClass} ${title || ""} ${url || ""}`.toLowerCase();
-
-        if (hint.includes("pdf")) return "pdf";
-        if (hint.includes("powerpoint") || hint.includes("ppt")) return "pptx";
-        if (hint.includes("word") || hint.includes("doc")) return "docx";
-        if (hint.includes("excel") || hint.includes("xlsx") || hint.includes("spreadsheet")) return "xlsx";
-        if (hint.includes("link") || hint.includes("url") || hint.includes("external")) return "link";
-        if (hint.includes("folder")) return "folder";
-        if (hint.includes("book") || hint.includes("page")) return "html";
-        return null;
-    };
-
-    const needsHeadProbe = (url, fileType) => Boolean(url && !fileType && (/pluginfile\.php/i.test(url) || /\/mod\/resource\//i.test(url)));
-
-    // Moodle often serves files via pluginfile.php without a reliable extension, so HEAD is used as a fallback.
-    const fetchHeadMetadata = async (url) => {
-        if (!url) return {};
-        try {
-            const response = await fetch(url, {
-                method: "HEAD",
-                credentials: "include",
-                redirect: "follow"
-            });
-            const contentType = response.headers.get("content-type") || "";
-            const disposition = response.headers.get("content-disposition") || "";
-            const nameMatch = disposition.match(/filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i);
-            const filename = decodeURIComponent((nameMatch?.[1] || nameMatch?.[2] || "").trim());
-            return {
-                contentType,
-                contentDisposition: disposition,
-                filename: filename || null
-            };
-        } catch (_) {
-            return {};
-        }
-    };
-
-    const classifyMaterialType = (activity, title, fileType, url) => {
-        const classList = activity?.className || "";
-        const text = `${title || ""} ${url || ""}`.toLowerCase();
-
-        if (classList.includes("assign") || text.includes("assignment")) return "assignment";
-        if (classList.includes("quiz") || text.includes("quiz")) return "quiz";
-        if (classList.includes("url") || fileType === "link") return "link";
-        if (classList.includes("folder") || text.includes("lab") || text.includes("tutorial")) return "lab";
-        if (fileType === "pdf") return "pdf";
-        if (["doc", "docx", "ppt", "pptx", "xls", "xlsx"].includes(fileType)) return "document";
-        if (classList.includes("page") || text.includes("lecture")) return "lecture";
-        if (classList.includes("resource")) return "lecture";
-        return "lecture";
-    };
-
-    const parseSectionName = (activity) => {
-        const section = activity?.closest("li.section, .course-section, .topics .section, section.course-section");
-        const heading = section?.querySelector(".sectionname, h3.sectionname, .section-title, .course-section-header h3");
-        return cleanText(heading?.textContent) || "General";
-    };
-
-    const parseAvailabilityStatus = (activity) => {
-        const availability = cleanText(activity?.querySelector(".availabilityinfo")?.textContent);
-        if (availability) return availability;
-
-        const restricted = activity?.classList.contains("dimmed") || activity?.classList.contains("hidden") || activity?.classList.contains("stealth");
-        return restricted ? "restricted" : "available";
-    };
-
-    const parseDueDate = (activity) => {
-        const explicitDate = cleanText(activity?.querySelector(".activitydate")?.textContent);
-        if (explicitDate) return explicitDate;
-
-        const text = cleanText(activity?.textContent);
-        const dueMatch = text?.match(/(?:due\s*(?:date|on)?\s*:?\s*)([^\n|]+)/i);
-        return dueMatch?.[1]?.trim() || null;
-    };
-
-    const parseFileSize = (activity) => {
-        const text = cleanText(activity?.textContent) || "";
-        const sizeMatch = text.match(/\b(\d+(?:\.\d+)?)\s?(KB|MB|GB)\b/i);
-        return sizeMatch ? `${sizeMatch[1]} ${sizeMatch[2].toUpperCase()}` : null;
-    };
-
-    const inferSemanticTags = ({ title, sectionName, materialType }) => {
-        const source = `${title || ""} ${sectionName || ""} ${materialType || ""}`.toLowerCase();
-        const tags = new Set();
-
-        if (/lecture|slides|week\s*\d+|topic/i.test(source)) tags.add("lecture");
-        if (/revision|review|summary|recap|past\s*paper/i.test(source)) tags.add("revision");
-        if (/exam|midterm|final|test|mock/i.test(source)) tags.add("exam");
-        if (/quiz|mcq/i.test(source) || materialType === "quiz") tags.add("quiz");
-        if (/lab|practical|workshop|exercise|practice|tutorial/i.test(source) || materialType === "lab") tags.add("practice");
-        if (/assignment|coursework|submission/i.test(source) || materialType === "assignment") tags.add("assignment");
-
-        if (tags.size === 0) {
-            tags.add(materialType === "link" ? "reference" : "general");
-        }
-
-        return Array.from(tags);
-    };
-
-    const evaluateDownloadability = (activity, materialType, url, contentDisposition) => {
-        const classList = activity?.className || "";
-        const isMoodleResource = classList.includes("modtype_resource") || classList.includes("resource");
-        const isResourceType = ["pdf", "lecture", "lab", "document"].includes(materialType);
-        return Boolean(
-            isMoodleResource ||
-                isResourceType ||
-                /\/mod\/resource\//i.test(url || "") ||
-                /pluginfile\.php/i.test(url || "") ||
-                /attachment/i.test(contentDisposition || "")
-        );
-    };
-
-    const extractMaterialsFromCourse = async (course) => {
-        const materials = [];
-        const seen = new Set();
-        const activities = document.querySelectorAll(".activity, li.activity, .modtype_resource, .course-section .activity-item");
-
-        const collected = Array.from(activities).map(async (activity) => {
-            const link = activity.querySelector("a.aalink, .activityname a, a[href]");
-            const title = cleanText(activity.querySelector(".instancename")?.textContent || link?.textContent);
-            const url = link?.href;
-            if (!title || !url) return null;
-
-            const materialId = parseMaterialId(url, activity);
-            let fileType = parseFileTypeFromDom(activity, title, url);
-            let contentType = null;
-            let contentDisposition = null;
-            let filename = null;
-
-            if (needsHeadProbe(url, fileType)) {
-                const headMetadata = await fetchHeadMetadata(url);
-                contentType = headMetadata.contentType || null;
-                contentDisposition = headMetadata.contentDisposition || null;
-                filename = headMetadata.filename || null;
-                fileType = fileType || mapMimeTypeToFileType(contentType) || null;
-            }
-
-            if (!fileType) {
-                const pathExtension = (url.split("?")[0].match(/\.([a-z0-9]+)$/i)?.[1] || "").toLowerCase();
-                fileType = pathExtension && pathExtension !== "php" ? pathExtension : "html";
-            }
-
-            const materialType = classifyMaterialType(activity, title, fileType, url);
-            const downloadable = evaluateDownloadability(activity, materialType, url, contentDisposition);
-            const dedupeKey = `${course.course_id || "unknown"}-${materialId}-${url}`;
-
-            if (seen.has(dedupeKey)) return null;
-            seen.add(dedupeKey);
-
-            return {
-                course_id: course.course_id,
-                course_name: course.course_name,
-                section_name: parseSectionName(activity),
-                material_id: materialId,
-                material_type: materialType,
-                title,
-                file_type: fileType,
-                file_size: parseFileSize(activity),
-                url,
-                downloadable,
-                original_filename: filename,
-                content_type: contentType,
-                due_date: parseDueDate(activity),
-                availability_status: parseAvailabilityStatus(activity),
-                semantic_tags: inferSemanticTags({ title, sectionName: parseSectionName(activity), materialType }),
-                extracted_at: new Date().toISOString()
-            };
-        });
-
-        const resolved = await Promise.all(collected);
-        resolved.filter(Boolean).forEach((item) => materials.push(item));
-
-        return materials;
-    };
-
     const extractGradesFromTable = (courseId) => {
         const grades = [];
         document.querySelectorAll("table.user-grade tbody tr").forEach((row) => {
             const itemName = cleanText(row.querySelector("th.column-itemname")?.textContent);
             const gradeText = cleanText(row.querySelector("td.column-grade")?.textContent);
-            const rangeText = cleanText(row.querySelector("td.column-range")?.textContent);
             if (!itemName || !gradeText) return;
-
-            const [gradeValue] = gradeText.split("/");
-            const maxGrade = rangeText?.split("/")[1] || rangeText;
-            const gradeNumber = parseFloat(gradeValue);
-            const maxNumber = parseFloat(maxGrade);
-            const percentage =
-                Number.isFinite(gradeNumber) && Number.isFinite(maxNumber) && maxNumber > 0
-                    ? Math.round((gradeNumber / maxNumber) * 100)
-                    : null;
-
             grades.push({
                 course_id: courseId,
                 item_name: itemName,
                 item_type: itemName.toLowerCase().includes("quiz") ? "quiz" : "assignment",
                 grade: gradeText,
-                max_grade: rangeText,
-                percentage,
-                submission_status: cleanText(row.querySelector("td.column-status")?.textContent),
-                submission_time: cleanText(row.querySelector("td.column-lastaccess")?.textContent)
+                submission_status: cleanText(row.querySelector("td.column-status")?.textContent)
             });
         });
         return grades;
@@ -309,42 +91,26 @@
     const extractAssignmentDetails = (courseId) => {
         const title = cleanText(document.querySelector("h1")?.textContent);
         const status = cleanText(document.querySelector(".submissionstatustable")?.textContent);
-        const dueDate = cleanText(document.querySelector(".submissionstatustable .duedate")?.textContent);
-        const grade = cleanText(document.querySelector(".gradingtable .grade")?.textContent);
-        return title
-            ? [
-                  {
-                      course_id: courseId,
-                      item_name: title,
-                      item_type: "assignment",
-                      grade,
-                      max_grade: null,
-                      percentage: null,
-                      submission_status: status,
-                      submission_time: null
-                  }
-              ]
-            : [];
+        return title ? [{ course_id: courseId, item_name: title, item_type: "assignment", submission_status: status, grade: null }] : [];
     };
 
     const extractQuizDetails = (courseId) => {
         const title = cleanText(document.querySelector("h1")?.textContent);
-        const gradeSummary = cleanText(document.querySelector(".quizgradefeedback")?.textContent);
-        const gradeInfo = cleanText(document.querySelector(".quizinfo")?.textContent);
-        return title
-            ? [
-                  {
-                      course_id: courseId,
-                      item_name: title,
-                      item_type: "quiz",
-                      grade: gradeSummary,
-                      max_grade: gradeInfo,
-                      percentage: null,
-                      submission_status: null,
-                      submission_time: null
-                  }
-              ]
-            : [];
+        const summary = cleanText(document.querySelector(".quizgradefeedback")?.textContent);
+        return title ? [{ course_id: courseId, item_name: title, item_type: "quiz", submission_status: null, grade: summary }] : [];
+    };
+
+    const extractVisibleMetricCounts = () => {
+        const sourceText = `${document.body?.innerText || ""}`;
+
+        const quizAttemptMatches = sourceText.match(/quiz\s+attempts?/gi) || [];
+        const assignmentSubmissionMatches = sourceText.match(/assignment\s+submissions?/gi) || [];
+
+        return {
+            // Extracted from currently visible page text, if present.
+            quiz_attempts: quizAttemptMatches.length,
+            assignment_submissions: assignmentSubmissionMatches.length
+        };
     };
 
     const sendMessage = (type, payload) => {
@@ -361,19 +127,20 @@
         });
     };
 
-    const handleScrape = async () => {
+    const handleScrape = () => {
         const pageType = detectPageType();
         const course = getCourseContext();
 
         sendMessage("identity", getStudentIdentity());
         sendPageView(pageType, course);
 
-        if (pageType === "course") {
-            const materials = await extractMaterialsFromCourse(course);
-            if (materials.length) {
-                sendMessage("materials", materials);
-            }
-        }
+        const visibleCounts = extractVisibleMetricCounts();
+        sendMessage("metrics_update", {
+            ...visibleCounts,
+            course_id: course.course_id,
+            course_name: course.course_name,
+            timestamp: Date.now()
+        });
 
         if (pageType === "grades") {
             const grades = extractGradesFromTable(course.course_id);
@@ -397,13 +164,22 @@
         }
     };
 
-    document.addEventListener("click", () => {
+    document.addEventListener("click", (event) => {
         const pageType = detectPageType();
         const course = getCourseContext();
+        const target = event.target;
+        const clickedLink = target instanceof Element ? target.closest("a[href]") : null;
+        const href = clickedLink?.getAttribute("href") || "";
+        const activityNode = target instanceof Element ? target.closest(".activity, li.activity, .activity-item") : null;
+        const isMaterialClick = Boolean(
+            activityNode || /\/mod\/(resource|page|url|folder|book)\//i.test(href) || /pluginfile\.php/i.test(href)
+        );
+
         sendMessage("interaction", {
             page_type: pageType,
             course_id: course.course_id,
-            action_type: "click",
+            course_name: course.course_name,
+            action_type: isMaterialClick ? "material_click" : "click",
             timestamp: Date.now()
         });
     });

--- a/moodle-ai-extension/popup.css
+++ b/moodle-ai-extension/popup.css
@@ -1,194 +1,137 @@
 :root {
     color-scheme: light;
-    font-family: Arial, sans-serif;
+    font-family: "Inter", "Segoe UI", Arial, sans-serif;
 }
 
 body {
     margin: 0;
     width: 390px;
-    background: #f8fafc;
-    color: #17212f;
+    background: linear-gradient(180deg, #f5f8ff 0%, #f7fafc 100%);
+    color: #192234;
 }
 
 .container {
-    padding: 12px;
+    padding: 14px;
 }
 
-h1 {
+.header h1 {
     margin: 0;
     font-size: 20px;
 }
 
-h2 {
-    margin: 0 0 10px;
-    font-size: 16px;
-}
-
 .subtle {
-    color: #5f6f86;
+    color: #60708a;
     font-size: 12px;
+    margin-top: 4px;
 }
 
 .card {
-    background: #ffffff;
-    border: 1px solid #d9e2ec;
-    border-radius: 10px;
+    background: #fff;
+    border: 1px solid #dce5f2;
+    border-radius: 12px;
     padding: 10px;
     margin-top: 10px;
+    box-shadow: 0 6px 20px rgba(34, 62, 102, 0.05);
+}
+
+.controls {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+label {
+    font-size: 12px;
+    color: #52637b;
+}
+
+select {
+    border: 1px solid #cfdbee;
+    border-radius: 10px;
+    background: #f9fbff;
+    color: #18243a;
+    padding: 8px;
+    font-size: 13px;
 }
 
 .stats-grid {
     margin-top: 10px;
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 9px;
+}
+
+.metric-card {
+    display: flex;
+    align-items: center;
     gap: 8px;
+    border-radius: 12px;
+    padding: 10px;
+    border: 1px solid transparent;
+    transition: transform 120ms ease, box-shadow 120ms ease;
 }
 
-.stat {
-    background: #ffffff;
-    border: 1px solid #d9e2ec;
-    border-radius: 10px;
-    padding: 8px;
+.metric-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 16px rgba(30, 58, 95, 0.08);
 }
 
-.stat .label {
+.metric-icon {
+    width: 30px;
+    height: 30px;
+    display: grid;
+    place-items: center;
+    border-radius: 9px;
+    background: rgba(255, 255, 255, 0.55);
+    font-size: 16px;
+}
+
+.metric-label {
     font-size: 12px;
-    color: #5f6f86;
+    color: #455670;
 }
 
-.stat .value {
-    font-size: 19px;
+.metric-value {
+    font-size: 18px;
     font-weight: 700;
 }
 
-.course-row {
-    border: 1px solid #e2e8f0;
-    border-left: 4px solid #8fa6be;
-    border-radius: 8px;
-    padding: 8px;
-    margin-bottom: 8px;
-    background: #fbfdff;
-}
-
-.course-row.high {
-    border-left-color: #2f9e44;
-}
-
-.course-row.medium {
-    border-left-color: #d08b16;
-}
-
-.course-row.low {
-    border-left-color: #c44545;
-}
-
-.course-row-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-
-.course-badges {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    margin: 6px 0;
-}
-
-.badge {
-    font-size: 11px;
-    color: #314155;
-    background: #eef4fb;
-    border: 1px solid #d6e4f5;
-    border-radius: 999px;
-    padding: 2px 8px;
-}
-
-.status-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    display: inline-block;
-}
-
-.status-dot.high {
-    background: #2f9e44;
-}
-
-.status-dot.medium {
-    background: #d08b16;
-}
-
-.status-dot.low {
-    background: #c44545;
-}
-
-.material-item {
-    border: 1px solid #e1e8f0;
-    border-radius: 8px;
-    padding: 8px;
-    margin-bottom: 8px;
-    background: #fafcff;
-}
-
-.material-meta {
-    font-size: 12px;
-    color: #526076;
-    margin: 4px 0;
-}
-
-.tag-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-    margin-top: 6px;
-}
-
-.tag-chip {
-    font-size: 11px;
-    border: 1px solid #d4deea;
-    border-radius: 999px;
-    padding: 2px 8px;
-    color: #405165;
-    background: #f1f5fb;
-}
-
-.row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 8px;
-}
-
-button {
-    border: 1px solid #c6d4e1;
-    border-radius: 8px;
-    background: #f5f8fc;
-    color: #1d2734;
-    cursor: pointer;
-    padding: 6px 10px;
-    font-size: 12px;
-}
-
-button.primary {
-    background: #1f6feb;
-    color: #fff;
-    border-color: #1f6feb;
-}
-
-button:disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
-}
-
-button.danger {
-    border-color: #e3a1a1;
-    color: #9f2424;
-}
+.tone-blue { background: #eaf4ff; border-color: #cfe7ff; }
+.tone-indigo { background: #edf0ff; border-color: #d6dcff; }
+.tone-cyan { background: #e9fbff; border-color: #c7eef9; }
+.tone-purple { background: #f3edff; border-color: #e1d4ff; }
+.tone-green { background: #ecfdf1; border-color: #caefdb; }
+.tone-orange { background: #fff3e8; border-color: #ffdcbf; }
 
 .actions {
     display: flex;
     gap: 8px;
+}
+
+button {
+    border: 1px solid #c8d7ea;
+    border-radius: 9px;
+    background: #f4f8ff;
+    color: #1b2738;
+    cursor: pointer;
+    padding: 7px 10px;
+    font-size: 12px;
+    flex: 1;
+}
+
+button:hover {
+    background: #e9f1ff;
+}
+
+button.danger {
+    border-color: #f0b3b3;
+    color: #a12f2f;
+    background: #fff4f4;
+}
+
+button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 .hidden {

--- a/moodle-ai-extension/popup.html
+++ b/moodle-ai-extension/popup.html
@@ -3,42 +3,33 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>AcademIQ Materials Dashboard</title>
+<title>AcademIQ Extracted Data</title>
 <link rel="stylesheet" href="popup.css">
 </head>
 <body>
   <main class="container">
-    <header>
-      <h1>Learning Materials</h1>
+    <header class="header">
+      <h1>Extracted Data</h1>
       <p id="lastUpdated" class="subtle">No extraction data yet</p>
     </header>
 
+    <section class="card controls">
+      <label for="courseSelect">Course</label>
+      <select id="courseSelect"></select>
+    </section>
+
     <section id="emptyState" class="card empty hidden">
-      <p>No learning materials found yet. Open Moodle course pages first.</p>
+      <p>No course behavior data found yet. Open Moodle course pages first.</p>
     </section>
 
     <section id="dashboard" class="hidden">
-      <div class="stats-grid" id="materialStats"></div>
-
-      <section class="card">
-        <h2>By Course</h2>
-        <div id="courseBreakdown"></div>
-      </section>
-
-      <section class="card">
-        <div class="row">
-          <h2>Materials</h2>
-          <button id="downloadAllPdfsBtn" class="primary" type="button">Download All Files</button>
-        </div>
-        <p id="downloadMeta" class="subtle">Download-ready files: 0</p>
-        <div id="materialsList" class="materials-list"></div>
-      </section>
+      <div class="stats-grid" id="metricsGrid"></div>
     </section>
 
     <section class="card actions">
       <button id="refreshBtn" type="button">Refresh</button>
       <button id="downloadJsonBtn" type="button">Download JSON</button>
-      <button id="clearDataBtn" type="button" class="danger">Clear Data</button>
+      <button id="clearDataBtn" type="button" class="danger">Clear Selected Course</button>
     </section>
   </main>
 

--- a/moodle-ai-extension/popup.js
+++ b/moodle-ai-extension/popup.js
@@ -4,32 +4,15 @@ const refs = {
     refreshBtn: document.getElementById("refreshBtn"),
     downloadJsonBtn: document.getElementById("downloadJsonBtn"),
     clearDataBtn: document.getElementById("clearDataBtn"),
-    downloadAllPdfsBtn: document.getElementById("downloadAllPdfsBtn"),
+    courseSelect: document.getElementById("courseSelect"),
     emptyState: document.getElementById("emptyState"),
     dashboard: document.getElementById("dashboard"),
-    materialStats: document.getElementById("materialStats"),
-    courseBreakdown: document.getElementById("courseBreakdown"),
-    materialsList: document.getElementById("materialsList"),
-    downloadMeta: document.getElementById("downloadMeta"),
+    metricsGrid: document.getElementById("metricsGrid"),
     lastUpdated: document.getElementById("lastUpdated")
 };
 
-let currentMaterials = [];
-let currentCourses = [];
-
-const sanitizePayload = (data) => {
-    if (!data) return null;
-    const { _meta, events, grades, learning_materials, courses, behavior, student, knowledge_base } = data;
-    return {
-        student,
-        courses,
-        behavior,
-        knowledge_base,
-        events: (events || []).map(({ _id, ...event }) => event),
-        grades: (grades || []).map(({ _key, ...grade }) => grade),
-        learning_materials: (learning_materials || []).map(({ _key, ...material }) => material)
-    };
-};
+let metricsByCourse = {};
+let selectedCourseId = "";
 
 const getStorageData = () =>
     new Promise((resolve) => {
@@ -38,240 +21,165 @@ const getStorageData = () =>
         });
     });
 
-const createStatCard = (label, value) => {
-    const el = document.createElement("div");
-    el.className = "stat";
-    el.innerHTML = `<div class="label">${label}</div><div class="value">${value}</div>`;
-    return el;
+const sanitizePayload = (data) => {
+    if (!data) return null;
+    return {
+        student: data.student || null,
+        // Raw extracted per-course counters, safe for export.
+        metricsByCourse: data.metricsByCourse || {},
+        events: (data.events || []).map(({ _id, ...event }) => event)
+    };
 };
 
-const inferType = (material) => material.material_type || "other";
-
-const computeTypeCounts = (materials) => {
-    const base = { lecture: 0, lab: 0, pdf: 0, document: 0, assignment: 0, quiz: 0, link: 0 };
-    materials.forEach((item) => {
-        const type = inferType(item);
-        if (base[type] !== undefined) {
-            base[type] += 1;
-        }
-    });
-    return base;
+const formatDuration = (seconds) => {
+    const total = Number(seconds || 0);
+    if (total < 60) return `${total}s`;
+    const mins = Math.floor(total / 60);
+    const rem = total % 60;
+    if (mins < 60) return `${mins}m ${rem}s`;
+    const hours = Math.floor(mins / 60);
+    const minsRem = mins % 60;
+    return `${hours}h ${minsRem}m`;
 };
 
-const inferFilename = (material, fallbackIndex = 0) => {
-    if (material.original_filename) return material.original_filename;
-    try {
-        const url = new URL(material.url);
-        const pathToken = decodeURIComponent(url.pathname.split("/").pop() || "").trim();
-        if (pathToken && pathToken.includes(".") && !pathToken.endsWith(".php")) return pathToken;
-    } catch (_) {
-        // Ignore URL parsing failure and fallback.
-    }
-
-    const title = (material.title || `material_${fallbackIndex + 1}`).replace(/[\\/:*?"<>|]+/g, "_").trim();
-    const ext = material.file_type && material.file_type !== "link" ? material.file_type : "bin";
-    return `${title || `material_${fallbackIndex + 1}`}.${ext}`;
+const createMetricCard = ({ icon, label, value, tone }) => {
+    const card = document.createElement("article");
+    card.className = `metric-card ${tone}`;
+    card.innerHTML = `
+        <div class="metric-icon">${icon}</div>
+        <div>
+            <div class="metric-label">${label}</div>
+            <div class="metric-value">${value}</div>
+        </div>
+    `;
+    return card;
 };
 
-const isMaterialDownloadable = (material) => material.downloadable === true && /^https?:/i.test(material.url || "") && material.material_type !== "link";
+const renderCourseOptions = () => {
+    refs.courseSelect.innerHTML = "";
+    const courseIds = Object.keys(metricsByCourse);
 
-const startDownload = (material, index = 0) =>
-    new Promise((resolve) => {
-        chrome.downloads.download(
-            {
-                url: material.url,
-                filename: inferFilename(material, index),
-                conflictAction: "uniquify",
-                saveAs: false
-            },
-            (downloadId) => {
-                if (downloadId) {
-                    resolve({ ok: true, method: "download" });
-                    return;
-                }
-
-                // Moodle resources can reject the Downloads API when URL token/session checks fail.
-                chrome.tabs.create({ url: material.url }, (tab) => {
-                    resolve({ ok: Boolean(tab?.id), method: tab?.id ? "tab" : "failed" });
-                });
-            }
-        );
-    });
-
-const getEngagementLevel = (course) => {
-    const score = (course.total_visits || 0) + (course.number_of_resources_clicked || 0) + Math.round((course.total_time_spent_seconds || 0) / 120);
-    if (score >= 25) return "high";
-    if (score >= 10) return "medium";
-    return "low";
-};
-
-const renderStats = (materials) => {
-    refs.materialStats.innerHTML = "";
-    const counts = computeTypeCounts(materials);
-
-    refs.materialStats.appendChild(createStatCard("Total Materials", materials.length));
-    refs.materialStats.appendChild(createStatCard("Lectures", counts.lecture));
-    refs.materialStats.appendChild(createStatCard("Labs / Tutorials", counts.lab));
-    refs.materialStats.appendChild(createStatCard("PDFs", counts.pdf));
-    refs.materialStats.appendChild(createStatCard("Documents", counts.document));
-    refs.materialStats.appendChild(createStatCard("Assignments", counts.assignment));
-    refs.materialStats.appendChild(createStatCard("Quizzes", counts.quiz));
-};
-
-const renderCourseBreakdown = (materials, courses) => {
-    refs.courseBreakdown.innerHTML = "";
-    const byCourse = new Map();
-
-    materials.forEach((item) => {
-        const courseName = item.course_name || `Course ${item.course_id || "Unknown"}`;
-        if (!byCourse.has(courseName)) {
-            byCourse.set(courseName, { lecture: 0, lab: 0, pdf: 0, document: 0, assignment: 0, quiz: 0, link: 0, materialCount: 0 });
-        }
-        const bucket = byCourse.get(courseName);
-        const type = inferType(item);
-        if (bucket[type] !== undefined) bucket[type] += 1;
-        bucket.materialCount += 1;
-    });
-
-    if (!byCourse.size) {
-        refs.courseBreakdown.textContent = "No course breakdown available.";
+    if (!courseIds.length) {
+        const option = document.createElement("option");
+        option.value = "";
+        option.textContent = "No courses";
+        refs.courseSelect.appendChild(option);
+        refs.courseSelect.disabled = true;
+        selectedCourseId = "";
         return;
     }
 
-    byCourse.forEach((counts, courseName) => {
-        const courseMetrics = (courses || []).find((c) => c.course_name === courseName) || {};
-        const engagement = getEngagementLevel(courseMetrics);
+    refs.courseSelect.disabled = false;
 
-        const row = document.createElement("div");
-        row.className = `course-row ${engagement}`;
-        row.innerHTML = `
-            <div class="course-row-header">
-                <strong>${courseName}</strong>
-                <span class="status-dot ${engagement}" title="${engagement} engagement"></span>
-            </div>
-            <div class="course-badges">
-                <span class="badge">👁️ ${courseMetrics.total_visits || 0}</span>
-                <span class="badge">🖱️ ${courseMetrics.number_of_resources_clicked || 0}</span>
-                <span class="badge">⏱️ ${Math.round((courseMetrics.total_time_spent_seconds || 0) / 60)}m</span>
-                <span class="badge">📚 ${counts.materialCount}</span>
-            </div>
-            <div class="material-meta">Lectures: ${counts.lecture} · Labs: ${counts.lab} · PDFs: ${counts.pdf} · Docs: ${counts.document} · Assignments: ${counts.assignment} · Quizzes: ${counts.quiz}</div>
-        `;
-        refs.courseBreakdown.appendChild(row);
+    courseIds.forEach((courseId) => {
+        const option = document.createElement("option");
+        option.value = courseId;
+        option.textContent = metricsByCourse[courseId].course_name || `Course ${courseId}`;
+        refs.courseSelect.appendChild(option);
     });
+
+    if (!selectedCourseId || !metricsByCourse[selectedCourseId]) {
+        selectedCourseId = courseIds[0];
+    }
+    refs.courseSelect.value = selectedCourseId;
 };
 
-const materialFileLabel = (material) => {
-    if (material.material_type === "link" || material.file_type === "link") return "External link";
-    if ((material.file_type || "").toLowerCase() === "pdf") return "PDF";
-    if (["doc", "docx", "ppt", "pptx", "xlsx"].includes((material.file_type || "").toLowerCase())) return "Document";
-    if (material.downloadable) return "Downloadable file";
-    return "Resource";
-};
+const renderMetrics = () => {
+    refs.metricsGrid.innerHTML = "";
+    const courseMetrics = metricsByCourse[selectedCourseId];
 
-const renderMaterialsList = (materials) => {
-    refs.materialsList.innerHTML = "";
-    if (!materials.length) {
-        refs.materialsList.textContent = "No materials available.";
+    if (!courseMetrics) {
+        refs.emptyState.classList.remove("hidden");
+        refs.dashboard.classList.add("hidden");
+        refs.clearDataBtn.disabled = true;
         return;
     }
 
-    materials.forEach((material, index) => {
-        const item = document.createElement("article");
-        item.className = "material-item";
+    refs.emptyState.classList.add("hidden");
+    refs.dashboard.classList.remove("hidden");
+    refs.clearDataBtn.disabled = false;
 
-        const dueDate = material.due_date ? `Due: ${material.due_date}` : "Due: N/A";
-        const availability = material.availability_status || "Unknown";
-        const fileInfo = `${materialFileLabel(material)}${material.file_size ? ` · ${material.file_size}` : ""}`;
-        const canDownload = isMaterialDownloadable(material);
-        const tags = Array.isArray(material.semantic_tags) ? material.semantic_tags : [];
+    const cards = [
+        {
+            icon: "⏱️",
+            label: "Total Time Spent",
+            value: formatDuration(courseMetrics.total_time_spent),
+            tone: "tone-blue"
+        },
+        {
+            icon: "👁️",
+            label: "Total Visits",
+            value: Number(courseMetrics.total_visits || 0),
+            tone: "tone-indigo"
+        },
+        {
+            icon: "🖱️",
+            label: "Material Clicks",
+            value: Number(courseMetrics.material_clicks || 0),
+            tone: "tone-cyan"
+        },
+        {
+            icon: "📅",
+            label: "Active Days",
+            value: Array.isArray(courseMetrics.active_days) ? courseMetrics.active_days.length : 0,
+            tone: "tone-purple"
+        },
+        {
+            icon: "📝",
+            label: "Quiz Attempts",
+            value: Number(courseMetrics.quiz_attempts || 0),
+            tone: "tone-green"
+        },
+        {
+            icon: "📤",
+            label: "Assignment Submissions",
+            value: Number(courseMetrics.assignment_submissions || 0),
+            tone: "tone-orange"
+        }
+    ];
 
-        item.innerHTML = `
-            <div class="row"><strong>${material.title || "Untitled Material"}</strong></div>
-            <div class="material-meta">${material.course_name || "Unknown Course"} · ${material.section_name || "General"}</div>
-            <div class="material-meta">Type: ${material.material_type || "unknown"} · File: ${fileInfo}</div>
-            <div class="material-meta">${dueDate} · Availability: ${availability}</div>
-            <div class="tag-row">${tags.map((tag) => `<span class="tag-chip">${tag}</span>`).join("")}</div>
-        `;
-
-        const button = document.createElement("button");
-        button.type = "button";
-        button.textContent = canDownload ? "Download" : "Open";
-        button.disabled = !material.url;
-        button.addEventListener("click", async () => {
-            const result = await startDownload(material, index);
-            if (!result.ok) {
-                button.textContent = "Open Failed";
-                return;
-            }
-            button.textContent = result.method === "tab" ? "Opened" : "Downloaded";
-        });
-
-        item.appendChild(button);
-        refs.materialsList.appendChild(item);
-    });
-};
-
-const renderDashboard = (materials, courses = []) => {
-    currentMaterials = materials || [];
-    currentCourses = courses || [];
-    const downloadableCount = currentMaterials.filter(isMaterialDownloadable).length;
-
-    refs.lastUpdated.textContent = `Last refreshed: ${new Date().toLocaleString()}`;
-    refs.downloadMeta.textContent = `Download-ready files: ${downloadableCount}`;
-
-    const isEmpty = currentMaterials.length === 0;
-    refs.emptyState.classList.toggle("hidden", !isEmpty);
-    refs.dashboard.classList.toggle("hidden", isEmpty);
-    refs.downloadAllPdfsBtn.disabled = downloadableCount === 0;
-
-    if (isEmpty) return;
-
-    renderStats(currentMaterials);
-    renderCourseBreakdown(currentMaterials, currentCourses);
-    renderMaterialsList(currentMaterials);
+    cards.forEach((cardData) => refs.metricsGrid.appendChild(createMetricCard(cardData)));
 };
 
 const refreshData = async () => {
     const data = await getStorageData();
-    const materials = Array.isArray(data?.learning_materials) ? data.learning_materials : [];
-    const courses = Array.isArray(data?.courses) ? data.courses : [];
-    renderDashboard(materials, courses);
+    metricsByCourse = data?.metricsByCourse && typeof data.metricsByCourse === "object" ? data.metricsByCourse : {};
+    renderCourseOptions();
+    renderMetrics();
+    refs.lastUpdated.textContent = `Last refreshed: ${new Date().toLocaleString()}`;
 };
 
-refs.downloadAllPdfsBtn.addEventListener("click", async () => {
-    const downloadableMaterials = currentMaterials.filter(isMaterialDownloadable);
-    let successCount = 0;
-
-    for (let i = 0; i < downloadableMaterials.length; i += 1) {
-        const result = await startDownload(downloadableMaterials[i], i);
-        if (result.ok) successCount += 1;
-    }
-
-    refs.downloadMeta.textContent = `Download-ready files: ${downloadableMaterials.length} · Started: ${successCount}`;
+refs.courseSelect.addEventListener("change", (event) => {
+    selectedCourseId = event.target.value;
+    renderMetrics();
 });
 
 refs.downloadJsonBtn.addEventListener("click", async () => {
     const data = await getStorageData();
-    if (!data) {
-        return;
-    }
+    if (!data) return;
 
     const payload = sanitizePayload(data);
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "moodle_student_data.json";
+    a.download = "moodle_extracted_data.json";
     a.click();
     URL.revokeObjectURL(url);
 });
 
 refs.clearDataBtn.addEventListener("click", () => {
-    chrome.runtime.sendMessage({ type: "clear_data" }, () => {
-        renderDashboard([], []);
-        refs.lastUpdated.textContent = "Data cleared";
-    });
+    if (!selectedCourseId) return;
+    chrome.runtime.sendMessage(
+        {
+            type: "clear_course",
+            payload: { course_id: selectedCourseId }
+        },
+        () => {
+            refreshData();
+            refs.lastUpdated.textContent = "Selected course data cleared";
+        }
+    );
 });
 
 refs.refreshBtn.addEventListener("click", refreshData);


### PR DESCRIPTION
### Motivation
- Remove learning-material harvesting and instead capture raw student behavior and performance counters from Moodle pages.  
- Ensure strict course isolation so metrics for one course never mix into another.  
- Provide a clean, human-readable popup that displays extracted counters per selected course for downstream use.

### Description
- Reworked background storage to store counters under `metricsByCourse[courseId]` and added a lightweight migration from the previous `courses` shape.  
- Implemented per-course raw counters: `total_time_spent`, `total_visits`, `material_clicks`, `active_days` (array), `quiz_attempts`, and `assignment_submissions`, and added `clear_course` to clear only the selected course.  
- Simplified the content script to emit only identity, page views, interaction events (detecting `material_click`), visible quiz/assignment counts (`metrics_update`), and grades; removed materials extraction and download logic.  
- Redesigned the popup into an "Extracted Data" dashboard with a course selector and compact metric cards (icons + soft color tones), JSON export of `metricsByCourse`, and course-scoped clear behavior; UI uses `chrome.storage.local` and keeps exported data human-readable.

### Testing
- Static syntax checks passed using `node --check` for `moodle-ai-extension/background.js`, `moodle-ai-extension/content.js`, and `moodle-ai-extension/popup.js` (all OK).  
- An automated attempt to render a screenshot of the popup using Playwright/http server failed due to environment file/HTTP access limitations in the runner (no changes to runtime behavior expected from this).  
- No backend calls, ML logic, or feature engineering were added; storage remains `chrome.storage.local` and data is kept as raw counters suitable for later ingestion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698550e99ff48332b411b81a2747b2e4)