### PR TITLE
Fix Moodle folder downloads, dedupe courses, and stabilize time tracking

### DIFF
--- a/moodle-ai-extension/popup.js
+++ b/moodle-ai-extension/popup.js
@@ -68,8 +68,16 @@ const getCourseMaterials = (data, courseId) => {
     return fromLegacy;
 };
 
+const getMaterialDownloadLabel = (material) => {
+    if (material.downloadStatus === "No downloadable files") return "No downloadable files";
+    if ((material.fileType || "").toLowerCase() === "folder" && !material.downloadable) return "No downloadable files";
+    return null;
+};
+
 const isMaterialDownloadable = (material) => {
     const fileType = (material.fileType || "").toLowerCase();
+    if (fileType === "folder") return false;
+    if (material.downloadStatus === "No downloadable files") return false;
     const hasDirectExt = /\.(pdf|doc|docx|ppt|pptx|xls|xlsx|zip)(\?|$)/i.test(material.url || "");
     return /^https?:/i.test(material.url || "") && (material.downloadable || hasDirectExt || (fileType !== "link" && fileType !== "unknown"));
 };
@@ -165,8 +173,9 @@ const renderMaterialsList = (materials) => {
 
             const button = document.createElement("button");
             button.type = "button";
-            button.textContent = canDownload ? "Download" : "View on Moodle";
-            button.disabled = !material.url;
+            const downloadLabel = getMaterialDownloadLabel(material);
+            button.textContent = downloadLabel || (canDownload ? "Download" : "View on Moodle");
+            button.disabled = Boolean(downloadLabel) || !material.url;
             button.addEventListener("click", async () => {
                 if (!canDownload) {
                     chrome.tabs.create({ url: material.url });


### PR DESCRIPTION
### Motivation
- Prevent Moodle “folder” resources from being downloaded as unusable HTML pages by treating folders as containers and only exposing real files for download. 
- Ensure the course selector shows each course only once by using a canonical key (prefer `course_id` with a normalized-name fallback) and merging discovered courses globally. 
- Make time-spent tracking accurate and stable by ensuring a single active timer per tab/course and stopping accumulation when the tab is hidden, navigated away, or the course changes. 

### Description
- `content.js`: added a one-time initialization guard (`window.__moodleAiContentInitialized`), explicit folder detection (`isFolderResource`), and folder-page scraping (`extractFolderFiles`) to extract only concrete downloadable file links (pdf/doc/docx/ppt/pptx/xls/xlsx/zip/txt/csv/rtf); empty folders are returned as non-downloadable with `downloadStatus: "No downloadable files"`. 
- `content.js`: suppresses duplicate `page_view` emissions using a page/course signature and emits a new `courses_catalog` payload when on the dashboard to help build a global course list. 
- `background.js`: introduced `getCourseKey` (uses `course_id` or normalized course name) and canonical merging in `toCourseMap`, `mergeCourse`, and `syncMetricsByCourse`; added handling for `courses_catalog` messages to merge discovered dashboard courses. 
- `background.js`: hardened active-tab timing (`activeTabs`) so only one timer per tab is active, timers are finalized on explicit transitions (`page_view` change, `page_hidden`, tab close), and tabs without a course are ignored when finalizing to avoid spurious accumulation. 
- `popup.js`: updated download affordances so folder entries and extracted-empty folders are clearly labeled and have download buttons disabled (`No downloadable files`), while valid file links remain download-ready. 

### Testing
- Ran syntax checks with `node --check content.js`, `node --check background.js`, and `node --check popup.js`, all succeeded. 
- Served the popup locally with `python3 -m http.server` and captured a UI screenshot via Playwright to validate popup rendering and disabled download states, which completed successfully. 
- Manual smoke validation of message flows and timer behavior in the background script during simulated page view/hide events (local runtime checks completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985775adb748332bb0da0fdbd59ed4a)